### PR TITLE
Changes ParseText to return IEnumerable of ILine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.5
+        dotnet-version: 5.0.202
 
     # Tool Restore
     - name: Tool Restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.403
+        dotnet-version: 5.0.5
 
     # Tool Restore
     - name: Tool Restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.5
+        dotnet-version: 5.0.202
 
     # Tool Restore
     - name: Tool Restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,5 +42,5 @@ jobs:
 
     # Publish
     - name: Publish
-      run: dotnet nuget push **/*.nupkg --api-key ${{ secrets.NUGET_DEPLOY_KEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push **/*.nupkg --api-key ${{ secrets.NUGET_DEPLOY_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
       working-directory: ./src/Fennel/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.403
+        dotnet-version: 5.0.5
 
     # Tool Restore
     - name: Tool Restore

--- a/src/Fennel/CSharp.fs
+++ b/src/Fennel/CSharp.fs
@@ -95,7 +95,7 @@ type Prometheus =
         let rs = P.parseText text
         
         match (rs |> Result.seq) with
-        | Ok x -> x
+        | Ok x -> x |> Seq.map Prometheus.ToILine
         | Error err -> failwith err
         
     static member Comment(text) = P.comment text

--- a/src/Fennel/Fennel.fsproj
+++ b/src/Fennel/Fennel.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <PackageId>Fennel</PackageId>
     <Title>Fennel Prometheus Translator</Title>
     <Authors>Devon Burriss</Authors>
@@ -12,6 +12,8 @@
     <License>https://github.com/dburriss/fennel/blob/master/LICENSE</License>
     <PackageTags>Prometheus Logs Metrics Parser Serialize Observability</PackageTags>
     <PackageReleaseNotes>
+      # 0.3.0
+      - Changes Prometheus.CSharp ParseText to return IEnumerable of ILine instead of Line
       # 0.2.0
       - Adds Prometheus.CSharp namespace with a more C# friendly API
     </PackageReleaseNotes>

--- a/test/Fennel.CSharp.Tests/CSharpApiTests.cs
+++ b/test/Fennel.CSharp.Tests/CSharpApiTests.cs
@@ -80,8 +80,9 @@ metric_without_timestamp_and_labels 12.47
 
 # A weird metric from before the epoch:
 something_weird{problem=""division by zero""} +Inf -3982045";
-            var result = Prometheus.ParseText(input);
+            var result = Prometheus.ParseText(input).ToArray();
             Assert.Equal(13, result.Count());
+            Assert.True(result[0].IsHelp);
         }
         
         [Fact]

--- a/test/Fennel.CSharp.Tests/Fennel.CSharp.Tests.csproj
+++ b/test/Fennel.CSharp.Tests/Fennel.CSharp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/test/Fennel.Tests.Unit/Fennel.Tests.Unit.fsproj
+++ b/test/Fennel.Tests.Unit/Fennel.Tests.Unit.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>


### PR DESCRIPTION
This is to address issue #1 as I believe returning `Line` instead of `ILine` for the CSharp API was a mistake.